### PR TITLE
Removed unnecessary publishing of vanilla assemblies.

### DIFF
--- a/TripsData/TripsData.csproj
+++ b/TripsData/TripsData.csproj
@@ -26,16 +26,7 @@
 
 	<ItemGroup>
 		<Reference Include="Colossal.PSI.Common">
-		  <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities Skylines II\Cities2_Data\Managed\Colossal.PSI.Common.dll</HintPath>
-		</Reference>
-		<Reference Include="Colossal.PSI.Discord">
-		  <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities Skylines II\Cities2_Data\Managed\Colossal.PSI.Discord.dll</HintPath>
-		</Reference>
-		<Reference Include="Colossal.PSI.PdxSdk">
-		  <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities Skylines II\Cities2_Data\Managed\Colossal.PSI.PdxSdk.dll</HintPath>
-		</Reference>
-		<Reference Include="Colossal.PSI.Steamworks">
-		  <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities Skylines II\Cities2_Data\Managed\Colossal.PSI.Steamworks.dll</HintPath>
+			<Private>false</Private>
 		</Reference>
 		<Reference Include="Game">
 			<Private>false</Private>


### PR DESCRIPTION
Made `Colossal.PSI.Common` private and removed unnecessary `Colossal.PSI.Discord`, `Colossal.PSI.PdxSdk`, `Colossal.PSI.Steamworks`.